### PR TITLE
Supporting methods for ILC calibration data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ all: lib/libcRIOcpp.a
 
 lib/libcRIOcpp.a: FORCE
 	$(MAKE) -C src libcRIOcpp.a
+	mkdir -p lib
+	mv src/libcRIOcpp.a lib/
 
 # Other Targets
 clean:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -24,10 +24,8 @@ LIBS := -ldl -lpthread
 BOOST_CPPFLAGS := -I/usr/include/boost169
 CPP_FLAGS := -lpthread
 
-GIT := $(shell command -v git 2> /dev/null)
-
-ifndef GIT
-   VERSION := "v0.0.0-None"
-else
-   VERSION := $(shell git describe --tags --dirty)
+VERSION := $(shell git describe --tags --dirty)
+ifeq ("$(VERSION)","")
+  $(warning "Cannot retrieve version by git, using v0.0.0-None")
+  VERSION := "v0.0.0-None"
 endif

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -23,3 +23,5 @@ LIBS := -ldl -lpthread
 
 BOOST_CPPFLAGS := -I/usr/include/boost169
 CPP_FLAGS := -lpthread
+
+VERSION := $(shell git describe --tags --dirty)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -24,4 +24,10 @@ LIBS := -ldl -lpthread
 BOOST_CPPFLAGS := -I/usr/include/boost169
 CPP_FLAGS := -lpthread
 
-VERSION := $(shell git describe --tags --dirty)
+GIT := $(shell command -v git 2> /dev/null)
+
+ifndef GIT
+   VERSION := "v0.0.0-None"
+else
+   VERSION := $(shell git describe --tags --dirty)
+endif

--- a/include/cRIO/ElectromechanicalPneumaticILC.h
+++ b/include/cRIO/ElectromechanicalPneumaticILC.h
@@ -34,8 +34,10 @@ class ElectromechanicalPneumaticILC : public ILC {
 public:
     /**
      * Populate responses for known ILC functions.
+     *
+     * @param bus ILC bus number (1..). Defaults to 1.
      */
-    ElectromechanicalPneumaticILC();
+    ElectromechanicalPneumaticILC(uint8_t bus = 1);
 
     /**
      * Unicast ADC Channel Offset and Sensitivity. ILC command code 81 (0x51)

--- a/include/cRIO/ElectromechanicalPneumaticILC.h
+++ b/include/cRIO/ElectromechanicalPneumaticILC.h
@@ -1,0 +1,77 @@
+/*
+ * Electromechanical and Pneumatic ILC functions.
+ *
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cRIO/ILC.h>
+
+namespace LSST {
+namespace cRIO {
+
+/**
+ * Class for communication with Electromechanical and Pneumatic ILCs.
+ *
+ * Replies received from ILCs shall be processed with ILC::processResponse method.
+ */
+class ElectromechanicalPneumaticILC : public ILC {
+public:
+    /**
+     * Populate responses for known ILC functions.
+     */
+    ElectromechanicalPneumaticILC();
+
+    /**
+     * Unicast ADC Channel Offset and Sensitivity. ILC command code 81 (0x51)
+     *
+     * @param address ILC address
+     * @param channel ADC channel (1-4)
+     * @param offset ADC offset value
+     * @param sensitivity ADC sensitivity value
+     */
+    void setOffsetAndSensitivity(uint8_t address, uint8_t channel, float offset, float sensitivity) {
+        callFunction(address, 81, 36500, channel, offset, sensitivity);
+    }
+
+    /**
+     * Read ILC calibration data. ILC command code 110 (0x6E).
+     *
+     * @param address ILC address
+     */
+    void reportCalibrationData(uint8_t address) { callFunction(address, 110, 1800); }
+
+protected:
+    /**
+     * Called when response from call to command 110 (0x6E) is read.
+     *
+     * @param address status returned from this ILC
+     * @param mainADCK[4] main ADC calibration Kn
+     * @param mainOffset[4] main sensor n offset
+     * @param mainSensitivity[4] main sensor n sensitivity
+     * @param backupADCK[4] backup ADC calibration Kn
+     * @param backupOffset[4] backup sensor n offset
+     * @param backupSensitivity[4] backup sensor n sensitivity
+     */
+    virtual void processCalibrationData(uint8_t address, float mainADCK[4], float mainOffset[4],
+                                        float mainSensitivity[4], float backupADCK[4],
+                                        float backupOffset[4], float backupSensitivity[4]) = 0;
+};
+
+}  // namespace cRIO
+}  // namespace LSST

--- a/include/cRIO/FPGA.h
+++ b/include/cRIO/FPGA.h
@@ -107,7 +107,7 @@ public:
      */
     virtual void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) = 0;
 
-    void writeCommandFIFO(uint16_t data, int32_t timeout) { writeCommandFIFO(&data, 1, timeout); }
+    void writeCommandFIFO(uint16_t data, uint32_t timeout) { writeCommandFIFO(&data, 1, timeout); }
 
     /**
      * Performs request for various data stored inside FPGA. This allows access
@@ -125,7 +125,7 @@ public:
      * @see readU8ResponseFIFO
      * @see readU16ResponseFIFO
      */
-    virtual void writeRequestFIFO(uint16_t* data, size_t length, int32_t timeout) = 0;
+    virtual void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) = 0;
 
     /**
      * Write single command into requestFIFO.
@@ -135,7 +135,7 @@ public:
      *
      * @throw NiError on NI error
      */
-    void writeRequestFIFO(uint16_t data, int32_t timeout) { writeRequestFIFO(&data, 1, timeout); }
+    void writeRequestFIFO(uint16_t data, uint32_t timeout) { writeRequestFIFO(&data, 1, timeout); }
 
     /**
      *
@@ -145,7 +145,7 @@ public:
      *
      * @throw NiError on NI error
      */
-    virtual void readU16ResponseFIFO(uint16_t* data, size_t length, int32_t timeout) = 0;
+    virtual void readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t timeout) = 0;
 
     /**
      * Wait for given IRQs.

--- a/include/cRIO/FPGA.h
+++ b/include/cRIO/FPGA.h
@@ -125,7 +125,7 @@ public:
      * @see readU8ResponseFIFO
      * @see readU16ResponseFIFO
      */
-    virtual void writeRequestFIFO(uint16_t* data, int32_t length, int32_t timeout) = 0;
+    virtual void writeRequestFIFO(uint16_t* data, size_t length, int32_t timeout) = 0;
 
     /**
      * Write single command into requestFIFO.
@@ -145,7 +145,7 @@ public:
      *
      * @throw NiError on NI error
      */
-    virtual void readU16ResponseFIFO(uint16_t* data, int32_t length, int32_t timeout) = 0;
+    virtual void readU16ResponseFIFO(uint16_t* data, size_t length, int32_t timeout) = 0;
 
     /**
      * Wait for given IRQs.
@@ -159,7 +159,7 @@ public:
     virtual void waitOnIrqs(uint32_t irqs, uint32_t timeout, uint32_t* triggered = NULL) = 0;
 
     /**
-     * Acknowledges IRQs. Clear IRSq on FPGA.
+     * Acknowledges IRQs. Clear IRQs on FPGA.
      *
      * @param irqs bitmask of IRQs to clear. FPGA has 32 IRQs channels, each
      * bit represents an interrupt.

--- a/include/cRIO/FPGA.h
+++ b/include/cRIO/FPGA.h
@@ -32,6 +32,12 @@ namespace LSST {
 namespace cRIO {
 
 /**
+ * FPGA Type. Currently only SS (Static Support) or TS (Thermal System) are
+ * known and supported.
+ */
+typedef enum { SS, TS } fpgaType;
+
+/**
  * Interface class for cRIO FPGA. Subclasses can talk either to the real HW, or
  * be a software simulator.
  *
@@ -42,6 +48,13 @@ namespace cRIO {
  */
 class FPGA {
 public:
+    /**
+     * Construct FPGA. Sets internal variable depending on FPGA type.
+     *
+     * @param type Either SS for Static Support FPGA or TS for Thermal System.
+     */
+    FPGA(fpgaType type);
+
     virtual ~FPGA() {}
 
     /**
@@ -160,6 +173,10 @@ protected:
      * @param timestamp received timestamp
      */
     virtual void reportTime(uint64_t begin, uint64_t end) {}
+
+private:
+    uint16_t _modbusSoftwareTrigger;
+    uint8_t _modbusIrq;
 };
 
 }  // namespace cRIO

--- a/include/cRIO/FPGA.h
+++ b/include/cRIO/FPGA.h
@@ -86,9 +86,44 @@ public:
     virtual void finalize() = 0;
 
     /**
-     * Send command to ILCs.
+     * Returns command used on CommandFIFO to write data to Modbus bus
+     * (transmit FIFO).
+     *
+     * @param bus bus number (1 based)
+     *
+     * @return command number
      */
-    void ilcCommands(uint16_t cmd, ILC& ilc);
+    virtual uint16_t getTxCommand(uint8_t bus) = 0;
+
+    /**
+     * Returns command used on RequestFIFO to read response from Modbus FIFO.
+     *
+     * @param bus bus number (1 based)
+     *
+     * @return command number
+     */
+    virtual uint16_t getRxCommand(uint8_t bus) = 0;
+
+    /**
+     * Returns IRQ associated with given bus.
+     *
+     * @param bus bus number (1 based)
+     *
+     * @return IRQ (bit based)
+     */
+    virtual uint32_t getIrq(uint8_t bus) = 0;
+
+    /**
+     * Send commands from ILC.
+     *
+     * @param ilc ILC class. That contains ModbusBuffer with commands. Its
+     * ILC::getBus() method returns bus used for communication.
+     *
+     * @see ILC
+     * @see ILC::getBus()
+     * @see ILC::processResponse()
+     */
+    void ilcCommands(ILC& ilc);
 
     /**
      * Writes buffer to command FIFO. Command FIFO is processed in

--- a/include/cRIO/ILC.h
+++ b/include/cRIO/ILC.h
@@ -44,8 +44,15 @@ class ILC : public ModbusBuffer {
 public:
     /**
      * Populate responses for know ILC functions.
+     *
+     * @param bus ILC bus number (1..). Defaults to 1.
      */
-    ILC();
+    ILC(uint8_t bus = 1);
+
+    /**
+     * Returns bus number. 1 based (1-5). 1=A,2=B,..5=E bus.
+     */
+    uint8_t getBus() { return _bus; }
 
     void reportServerID(uint8_t address) { callFunction(address, 17, 835); }
     void reportServerStatus(uint8_t address) { callFunction(address, 18, 270); }
@@ -127,9 +134,9 @@ public:
 protected:
     /**
      */
-    virtual void preProcess() {};
+    virtual void preProcess(){};
 
-    virtual void postProcess() {};
+    virtual void postProcess(){};
 
     /**
      * Callback for reponse to ServerID request. See LTS-646 Code 17 (0x11) for
@@ -267,6 +274,8 @@ protected:
     bool responseMatchCached(uint8_t address, uint8_t func);
 
 private:
+    uint8_t _bus;
+
     std::map<uint8_t, std::function<void(uint8_t)>> _actions;
     std::map<uint8_t, std::pair<uint8_t, std::function<void(uint8_t, uint8_t)>>> _errorActions;
 

--- a/include/cRIO/ILC.h
+++ b/include/cRIO/ILC.h
@@ -62,6 +62,11 @@ public:
     uint8_t getBus() { return _bus; }
 
     /**
+     * Set whenever all received data will trigger callback calls.
+     */
+    void setAlwaysTrigger(bool newAlwaysTrigger) { _alwaysTrigger = newAlwaysTrigger; }
+
+    /**
      * Calls function 17 (0x11), ask for ILC identity.
      *
      * @param address ILC address
@@ -94,7 +99,7 @@ public:
      */
     void changeILCMode(uint8_t address, uint16_t mode) { callFunction(address, 65, 335, mode); }
 
-    /** 
+    /**
      * Set temporary ILC address. ILC must be address-less (attached to address
      * 255). Can be used only if one ILC on a bus failed to read its address
      * from its network connection and therefore adopts the failure address
@@ -345,6 +350,7 @@ private:
     uint8_t _broadcastCounter;
     unsigned int _timestampShift;
 
+    bool _alwaysTrigger;
     std::map<uint8_t, std::map<uint8_t, std::vector<uint8_t>>> _cachedResponse;
 };
 

--- a/include/cRIO/ModbusBuffer.h
+++ b/include/cRIO/ModbusBuffer.h
@@ -18,8 +18,8 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MODBUSBUFFER_H_
-#define MODBUSBUFFER_H_
+#ifndef CRIO_MODBUSBUFFER_H_
+#define CRIO_MODBUSBUFFER_H_
 
 #include <cRIO/DataTypes.h>
 #include <queue>
@@ -504,4 +504,4 @@ inline void ModbusBuffer::write(float data) {
 }  // namespace cRIO
 }  // namespace LSST
 
-#endif /* MODBUSBUFFER_H_ */
+#endif /* CRIO_MODBUSBUFFER_H_ */

--- a/include/cRIO/ThermalILC.h
+++ b/include/cRIO/ThermalILC.h
@@ -39,8 +39,10 @@ class ThermalILC : public ILC {
 public:
     /**
      * Populate responses for known ILC functions.
+     *
+     * @param bus ILC bus number (1..). Defaults to 1.
      */
-    ThermalILC();
+    ThermalILC(uint8_t bus = 1);
 
     /**
      * Unicast heater PWM and fan RPM. ILC command code 88 (0x58)

--- a/include/cRIO/version.h
+++ b/include/cRIO/version.h
@@ -1,0 +1,37 @@
+/*
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CRIO_version_H
+#define CRIO_version_H
+
+namespace LSST {
+namespace cRIO {
+
+/**
+ * Return cRIO version.
+ *
+ * @return version of cRIO library
+ */
+const char *version();
+
+}  // namespace cRIO
+}  // namespace LSST
+
+#endif /* CRIO_version_H */

--- a/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
+++ b/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
@@ -45,7 +45,8 @@ ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC(uint8_t bus) : ILC(
                                backupSensitivity);
     };
 
-    addResponse(81, [this](uint8_t address) { checkCRC(); }, 235);
+    addResponse(81,
+            [this](uint8_t address) { checkCRC(); }, 235);
 
     addResponse(110, calibrationData, 238);
 }

--- a/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
+++ b/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
@@ -45,8 +45,8 @@ ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC(uint8_t bus) : ILC(
                                backupSensitivity);
     };
 
-    addResponse(81,
-            [this](uint8_t address) { checkCRC(); }, 235);
+    addResponse(
+            81, [this](uint8_t address) { checkCRC(); }, 235);
 
     addResponse(110, calibrationData, 238);
 }

--- a/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
+++ b/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
@@ -45,7 +45,8 @@ ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC() {
                                backupSensitivity);
     };
 
-    addResponse(81, [this](uint8_t address) { checkCRC(); }, 235);
+    addResponse(
+            81, [this](uint8_t address) { checkCRC(); }, 235);
 
     addResponse(110, calibrationData, 238);
 }

--- a/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
+++ b/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
@@ -1,0 +1,54 @@
+/*
+ * Electromechanical and Pneumatic ILC functions.
+ *
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cRIO/ElectromechanicalPneumaticILC.h>
+
+namespace LSST {
+namespace cRIO {
+
+ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC() {
+    auto calibrationData = [this](uint8_t address) {
+        float mainADCK[4], mainOffset[4], mainSensitivity[4], backupADCK[4], backupOffset[4],
+                backupSensitivity[4];
+        auto read4 = [this](float a[4]) {
+            for (int n = 0; n < 4; n++) {
+                a[n] = read<float>();
+            }
+        };
+        read4(mainADCK);
+        read4(mainOffset);
+        read4(mainSensitivity);
+        read4(backupADCK);
+        read4(backupOffset);
+        read4(backupSensitivity);
+        checkCRC();
+        processCalibrationData(address, mainADCK, mainOffset, mainSensitivity, backupADCK, backupOffset,
+                               backupSensitivity);
+    };
+
+    addResponse(81, [this](uint8_t address) { checkCRC(); }, 235);
+
+    addResponse(110, calibrationData, 238);
+}
+
+}  // namespace cRIO
+}  // namespace LSST

--- a/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
+++ b/src/LSST/cRIO/ElectromechanicalPneumaticILC.cpp
@@ -25,7 +25,7 @@
 namespace LSST {
 namespace cRIO {
 
-ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC() {
+ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC(uint8_t bus) : ILC(bus) {
     auto calibrationData = [this](uint8_t address) {
         float mainADCK[4], mainOffset[4], mainSensitivity[4], backupADCK[4], backupOffset[4],
                 backupSensitivity[4];
@@ -45,8 +45,7 @@ ElectromechanicalPneumaticILC::ElectromechanicalPneumaticILC() {
                                backupSensitivity);
     };
 
-    addResponse(
-            81, [this](uint8_t address) { checkCRC(); }, 235);
+    addResponse(81, [this](uint8_t address) { checkCRC(); }, 235);
 
     addResponse(110, calibrationData, 238);
 }

--- a/src/LSST/cRIO/ILC.cpp
+++ b/src/LSST/cRIO/ILC.cpp
@@ -31,6 +31,7 @@ namespace cRIO {
 ILC::ILC(uint8_t bus) {
     _bus = bus;
     _broadcastCounter = 0;
+    _alwaysTrigger = false;
 
     addResponse(
             17,
@@ -169,7 +170,7 @@ bool ILC::responseMatchCached(uint8_t address, uint8_t func) {
     try {
         std::map<uint8_t, std::vector<uint8_t>> &fc = _cachedResponse.at(address);
         try {
-            return checkRecording(fc[func]);
+            return checkRecording(fc[func]) && !_alwaysTrigger;
         } catch (std::out_of_range &ex1) {
             _cachedResponse[address].emplace(func, std::vector<uint8_t>());
         }
@@ -178,7 +179,7 @@ bool ILC::responseMatchCached(uint8_t address, uint8_t func) {
                 address,
                 std::map<uint8_t, std::vector<uint8_t>>({std::make_pair(func, std::vector<uint8_t>())})));
     }
-    return checkRecording(_cachedResponse[address][func]);
+    return checkRecording(_cachedResponse[address][func]) && !_alwaysTrigger;
 }
 
 }  // namespace cRIO

--- a/src/LSST/cRIO/ILC.cpp
+++ b/src/LSST/cRIO/ILC.cpp
@@ -28,7 +28,8 @@
 namespace LSST {
 namespace cRIO {
 
-ILC::ILC() {
+ILC::ILC(uint8_t bus) {
+    _bus = bus;
     _broadcastCounter = 0;
 
     addResponse(

--- a/src/LSST/cRIO/ThermalILC.cpp
+++ b/src/LSST/cRIO/ThermalILC.cpp
@@ -25,7 +25,7 @@
 namespace LSST {
 namespace cRIO {
 
-ThermalILC::ThermalILC() {
+ThermalILC::ThermalILC(uint8_t bus) : ILC(bus) {
     auto thermalStatus = [this](uint8_t address) {
         uint8_t status = read<uint8_t>();
         float differentialTemperature = read<float>();

--- a/src/LSST/cRIO/version.cpp
+++ b/src/LSST/cRIO/version.cpp
@@ -1,0 +1,29 @@
+/*
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cRIO/version.h>
+
+namespace LSST {
+namespace cRIO {
+
+const char *version() { return VERSION; }
+
+}  // namespace cRIO
+}  // namespace LSST

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,8 @@ endif
 
 CPPFLAGS := -I. \
 	-I"../include" \
-	-I"."
+	-I"." \
+	-DVERSION="\"$(VERSION)\""
 
 libcRIOcpp.a: $(OBJS)
 	@echo '[AR ] $@'

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,8 +29,8 @@ junit: compile
 clean:
 	@$(foreach df,$(BINARIES) $(DEPS) $(JUNIT_FILES),echo '[RM ] ${df}'; $(RM) ${df};)
 
-../src/libM1M3SS.a: FORCE
-	@$(MAKE) -C ../src libM1M3SS.a SIMULATOR=1
+../lib/libcRIOcpp.a: FORCE
+	@$(MAKE) -C ../ lib/libcRIOcpp.a SIMULATOR=1
 
 %.cpp.o: %.cpp.d
 	@echo '[CPP] $(patsubst %.d,%,$<)'
@@ -40,6 +40,6 @@ clean:
 	@echo '[DPP] $<'
 	${co}$(CPP) $(BOOST_CPPFLAGS) $(CPP_FLAGS) $(TEST_CPPFLAGS) -M $< -MF $@ -MT '$(patsubst %.cpp,%.o,$<) $@'
 
-${BINARIES}: %: %.cpp.o ../src/libcRIOcpp.a
+${BINARIES}: %: %.cpp.o ../lib/libcRIOcpp.a
 	@echo '[TPP] $<'
 	${co}$(CPP) -o $@ $(LIBS_FLAGS) $(LIBS) $^ $(CPP_FLAGS)

--- a/tests/test_ElectromechanicalPneumaticILC.cpp
+++ b/tests/test_ElectromechanicalPneumaticILC.cpp
@@ -1,0 +1,143 @@
+/*
+ * This file is part of LSST cRIOcpp test suite. Tests ILC generic functions.
+ *
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch/catch.hpp>
+
+#include <memory>
+#include <cmath>
+
+#include <cRIO/ElectromechanicalPneumaticILC.h>
+
+using namespace LSST::cRIO;
+
+class TestElectromechanicalPneumaticILC : public ElectromechanicalPneumaticILC {
+public:
+    TestElectromechanicalPneumaticILC() {
+        auto set_nan = [](float a[4]) {
+            for (int i = 0; i < 4; i++) {
+                a[i] = std::nan("f");
+            }
+        };
+        set_nan(responseMainADCK);
+        set_nan(responseMainOffset);
+        set_nan(responseMainSensitivity);
+        set_nan(responseBackupADCK);
+        set_nan(responseBackupOffset);
+        set_nan(responseBackupSensitivity);
+    }
+
+    float responseMainADCK[4];
+    float responseMainOffset[4];
+    float responseMainSensitivity[4];
+    float responseBackupADCK[4];
+    float responseBackupOffset[4];
+    float responseBackupSensitivity[4];
+
+protected:
+    void processServerID(uint8_t address, uint64_t uniqueID, uint8_t ilcAppType, uint8_t networkNodeType,
+                         uint8_t ilcSelectedOptions, uint8_t networkNodeOptions, uint8_t majorRev,
+                         uint8_t minorRev, std::string firmwareName) override {}
+
+    void processServerStatus(uint8_t address, uint8_t mode, uint16_t status, uint16_t faults) override {}
+
+    void processChangeILCMode(uint8_t address, uint16_t mode) override {}
+
+    void processSetTempILCAddress(uint8_t address, uint8_t newAddress) override {}
+
+    void processResetServer(uint8_t address) override {}
+
+    void processCalibrationData(uint8_t address, float mainADCK[4], float mainOffset[4],
+                                float mainSensitivity[4], float backupADCK[4], float backupOffset[4],
+                                float backupSensitivity[4]) {
+        memcpy(responseMainADCK, mainADCK, sizeof(responseMainADCK));
+        memcpy(responseMainOffset, mainOffset, sizeof(responseMainOffset));
+        memcpy(responseMainSensitivity, mainSensitivity, sizeof(responseMainSensitivity));
+
+        memcpy(responseBackupADCK, backupADCK, sizeof(responseBackupADCK));
+        memcpy(responseBackupOffset, backupOffset, sizeof(responseBackupOffset));
+        memcpy(responseBackupSensitivity, backupSensitivity, sizeof(responseBackupSensitivity));
+    }
+};
+
+TEST_CASE("Test set offset and sensitivity", "[ElectromechaniclPneumaticILC]") {
+    TestElectromechanicalPneumaticILC ilc;
+
+    ilc.setOffsetAndSensitivity(231, 1, 2.34, -4.56);
+
+    ilc.reset();
+
+    REQUIRE(ilc.read<uint8_t>() == 231);
+    REQUIRE(ilc.read<uint8_t>() == 81);
+    REQUIRE(ilc.read<uint8_t>() == 1);
+    REQUIRE(ilc.read<float>() == 2.34f);
+    REQUIRE(ilc.read<float>() == -4.56f);
+    REQUIRE_NOTHROW(ilc.checkCRC());
+    REQUIRE_NOTHROW(ilc.readEndOfFrame());
+    REQUIRE(ilc.readWaitForRx() == 37000);
+}
+
+TEST_CASE("Test parsing of calibration data", "[ElectromechaniclPneumaticILC]") {
+    TestElectromechanicalPneumaticILC ilc, response;
+
+    ilc.reportCalibrationData(17);
+
+    ilc.reset();
+
+    REQUIRE(ilc.read<uint8_t>() == 17);
+    REQUIRE(ilc.read<uint8_t>() == 110);
+    REQUIRE_NOTHROW(ilc.checkCRC());
+    REQUIRE_NOTHROW(ilc.readEndOfFrame());
+    REQUIRE(ilc.readWaitForRx() == 1800);
+
+    response.write<uint8_t>(17);
+    response.write<uint8_t>(110);
+    auto write4 = [&response](float base) {
+        for (int i = 0; i < 4; i++) {
+            response.write<float>(base * i);
+        }
+    };
+
+    write4(3.141592);
+    write4(2);
+    write4(-56.3211);
+    write4(2021.5788);
+    write4(789564687.4545);
+    write4(-478967.445456);
+
+    response.writeCRC();
+
+    REQUIRE_NOTHROW(ilc.processResponse(response.getBuffer(), response.getLength()));
+
+    auto check4 = [](float base, float values[4]) {
+        for (int i = 0; i < 4; i++) {
+            REQUIRE(values[i] == base * i);
+        }
+    };
+
+    check4(3.141592, ilc.responseMainADCK);
+    check4(2, ilc.responseMainOffset);
+    check4(-56.3211, ilc.responseMainSensitivity);
+    check4(2021.5788, ilc.responseBackupADCK);
+    check4(789564687.4545, ilc.responseBackupOffset);
+    check4(-478967.445456, ilc.responseBackupSensitivity);
+}

--- a/tests/test_ILC.cpp
+++ b/tests/test_ILC.cpp
@@ -73,8 +73,6 @@ public:
 
     uint8_t lastReset;
 
-    bool checkCached(uint8_t address, uint8_t function) { return ILC::checkCached(address, function); };
-
 protected:
     void processServerID(uint8_t address, uint64_t uniqueID, uint8_t ilcAppType, uint8_t networkNodeType,
                          uint8_t ilcSelectedOptions, uint8_t networkNodeOptions, uint8_t majorRev,

--- a/tests/test_ILC.cpp
+++ b/tests/test_ILC.cpp
@@ -433,9 +433,9 @@ TEST_CASE("Response cache management", "[ILC]") {
 
     ilc1.reportServerID(18);
 
-    auto constructResponse = [&ilc2](uint8_t id1) {
+    auto constructResponse = [&ilc2](uint8_t address, uint8_t id1) {
         ilc2.clear();
-        ilc2.write<uint8_t>(18);
+        ilc2.write<uint8_t>(address);
         ilc2.write<uint8_t>(17);
         ilc2.write<uint8_t>(15);
 
@@ -460,7 +460,7 @@ TEST_CASE("Response cache management", "[ILC]") {
         ilc2.writeCRC();
     };
 
-    constructResponse('A');
+    constructResponse(18, 'A');
 
     REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
     REQUIRE(ilc1.serverIDCallCounter == 1);
@@ -469,17 +469,47 @@ TEST_CASE("Response cache management", "[ILC]") {
     REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
     REQUIRE(ilc1.serverIDCallCounter == 1);
 
-    constructResponse('a');
+    constructResponse(11, 'A');
 
-    ilc1.reportServerID(18);
+    ilc1.reportServerID(11);
     REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
     REQUIRE(ilc1.serverIDCallCounter == 2);
 
-    ilc1.reportServerID(18);
+    ilc1.reportServerID(11);
     REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
     REQUIRE(ilc1.serverIDCallCounter == 2);
 
+    constructResponse(18, 'a');
+
     ilc1.reportServerID(18);
     REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
-    REQUIRE(ilc1.serverIDCallCounter == 2);
+    REQUIRE(ilc1.serverIDCallCounter == 3);
+
+    ilc1.reportServerID(18);
+    REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
+    REQUIRE(ilc1.serverIDCallCounter == 3);
+
+    ilc1.reportServerID(18);
+    REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
+    REQUIRE(ilc1.serverIDCallCounter == 3);
+
+    constructResponse(11, 'a');
+
+    ilc1.reportServerID(11);
+    REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
+    REQUIRE(ilc1.serverIDCallCounter == 4);
+
+    ilc1.setAlwaysTrigger(true);
+
+    constructResponse(18, 'a');
+
+    ilc1.reportServerID(18);
+    REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
+    REQUIRE(ilc1.serverIDCallCounter == 5);
+
+    constructResponse(11, 'a');
+
+    ilc1.reportServerID(11);
+    REQUIRE_NOTHROW(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()));
+    REQUIRE(ilc1.serverIDCallCounter == 6);
 }

--- a/tests/test_ILC.cpp
+++ b/tests/test_ILC.cpp
@@ -73,6 +73,8 @@ public:
 
     uint8_t lastReset;
 
+    bool checkCached(uint8_t address, uint8_t function) { return ILC::checkCached(address, function); };
+
 protected:
     void processServerID(uint8_t address, uint64_t uniqueID, uint8_t ilcAppType, uint8_t networkNodeType,
                          uint8_t ilcSelectedOptions, uint8_t networkNodeOptions, uint8_t majorRev,

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -25,7 +25,12 @@
 
 #include <cRIO/version.h>
 
+#include <iostream>
+
 using namespace LSST::cRIO;
 using Catch::Matchers::StartsWith;
 
-TEST_CASE("Version is reported", "[version]") { REQUIRE_THAT(version(), StartsWith("v")); }
+TEST_CASE("Version is reported", "[version]") {
+    std::cout << "Version: " << version() << std::endl;
+    REQUIRE_THAT(version(), StartsWith("v"));
+}

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of LSST cRIOcpp test suite. Tests ILC generic functions.
+ *
+ * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
+ * This product includes software developed by the Vera C.Rubin Observatory Project
+ * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
+ * this distribution for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch/catch.hpp>
+
+#include <cRIO/version.h>
+
+using namespace LSST::cRIO;
+using Catch::Matchers::StartsWith;
+
+TEST_CASE("Version is reported", "[version]") { REQUIRE_THAT(version(), StartsWith("v")); }


### PR DESCRIPTION
Added ElectromechanicalILC class. setAlwaysTrigger method to disable auto
filtering of know events (used in command line client, where all data needs to
be fresh). Introduce FPGA type. Small datatype fixes.