### PR TITLE
Changes to enable compilation to work on openSUSE Linux

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -3,7 +3,7 @@ ifndef VERBOSE
   co := @
 endif
 
-c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+c_opts := -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE `pkg-config --cflags spdlog`
 
 ifdef DEBUG
   c_opts += -g

--- a/src/LSST/cRIO/CSC.cpp
+++ b/src/LSST/cRIO/CSC.cpp
@@ -28,6 +28,9 @@
 #include <pwd.h>
 #include <csignal>
 
+#include <unistd.h>
+#include <fcntl.h>
+
 #include <spdlog/async.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/daily_file_sink.h>

--- a/src/LSST/cRIO/CliApp.cpp
+++ b/src/LSST/cRIO/CliApp.cpp
@@ -30,6 +30,8 @@
 #include <cmath>
 #include <csignal>
 
+#include <sys/stat.h>
+
 #include <readline/readline.h>
 #include <readline/history.h>
 

--- a/src/LSST/cRIO/Settings/Path.cpp
+++ b/src/LSST/cRIO/Settings/Path.cpp
@@ -19,8 +19,9 @@
  */
 
 #include <spdlog/spdlog.h>
-
 #include <cRIO/Settings/Path.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 using namespace LSST::cRIO::Settings;
 


### PR DESCRIPTION
Several header files had to be added, and also changes
in the Makefile to allow for system-installed (but not header only) spdlog