### PR TITLE
Improved error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lib/libcRIOcpp.a: FORCE
 
 # Other Targets
 clean:
-	@$(foreach file,doc,echo '[RM ] ${file}'; $(RM) -r $(file);)
+	@$(foreach file,,echo '[RM ] ${file}'; $(RM) -r $(file);)
 	@$(foreach dir,src tests,$(MAKE) -C ${dir} $@;)
 
 tests: tests/Makefile tests/*.cpp

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -4,7 +4,7 @@ ifndef VERBOSE
   silence := --silence-errors
 endif
 
-c_opts :=  -fdata-sections -ffunction-sections -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE -DSPDLOG_FMT_EXTERNAL
+c_opts :=  -fdata-sections -ffunction-sections -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE # -DSPDLOG_FMT_EXTERNAL
 
 ifdef DEBUG
   c_opts += -g

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -6,6 +6,7 @@ v1.10.0
 =======
 
 * handleMissingReply, MissingReply exception
+* IRQTimeout handling
 
 v1.9.0
 ======

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -2,6 +2,11 @@
 Version History
 ###############
 
+v1.10.0
+=======
+
+* handleMissingReply, MissingReply exception
+
 v1.9.0
 ======
 

--- a/include/cRIO/CliApp.h
+++ b/include/cRIO/CliApp.h
@@ -18,12 +18,10 @@
 #ifndef __CliApp_h
 #define __CliApp_h
 
-#include <iomanip>
 #include <iostream>
-#include <ostream>
 
 #include <cRIO/Application.h>
-#include <cRIO/OStreamRestore.h>
+#include <cRIO/ModbusBuffer.h>
 
 namespace LSST {
 namespace cRIO {
@@ -226,13 +224,7 @@ get_the_answer command.
      */
     template <typename dt>
     static const void printHexBuffer(dt* buf, size_t len, std::ostream& os = std::cout) {
-        OStreamRestore res(os);
-
-        os << std::hex << std::setfill('0');
-        for (size_t i = 0; i < len; i++) {
-            os << " " << std::setw(sizeof(dt) * 2) << +(buf[i]);
-        }
-        os << std::dec;
+        os << ModbusBuffer::hexDump<dt>(buf, len);
     }
 
     static const void printDecodedBuffer(uint16_t* buf, size_t len, std::ostream& os = std::cout);

--- a/include/cRIO/Command.h
+++ b/include/cRIO/Command.h
@@ -21,8 +21,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef COMMAND_H_
-#define COMMAND_H_
+#ifndef __CRIO_COMMAND_H_
+#define __CRIO_COMMAND_H_
 
 #include <string>
 
@@ -74,4 +74,4 @@ public:
 }  // namespace cRIO
 }  // namespace LSST
 
-#endif /* COMMAND_H_ */
+#endif /* __CRIO_COMMAND_H_ */

--- a/include/cRIO/DataTypes.h
+++ b/include/cRIO/DataTypes.h
@@ -1,27 +1,34 @@
 /*
- * Developed for the Vera C. Rubin Observatory Telescope & Site Software Systems.
- * This product includes software developed by the Vera C.Rubin Observatory Project
- * (https://www.lsst.org). See the COPYRIGHT file at the top-level directory of
- * this distribution for details of code ownership.
+ * This file is part of LSST M1M3 support system package.
  *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or (at your option)
- * any later version.
+ * Developed for the Vera C. Rubin Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
- * more details.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * You should have received a copy of the GNU General Public License along with
- * this program. If not, see <https://www.gnu.org/licenses/>.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef DATATYPES_H_
 #define DATATYPES_H_
 
 #include <stdint.h>
+
+#define ACK_INPROGRESS 301  //* Acknowledges command reception, command is being executed.
+#define ACK_COMPLETE 303    //* Command is completed.
+#define ACK_FAILED -302     //* Command execution failed.
 
 /**
  * Number of ModBus subnets. Subnets are connected and commanded through cRIO
@@ -40,6 +47,15 @@
 
 /// Number of actuators in Z axis - shall equal to total number of actuators.
 #define FA_Z_COUNT 156
+
+/// Number of secondary (X or Y) actuators.
+#define FA_S_COUNT (FA_X_COUNT + FA_Y_COUNT)
+
+/// Maximal number of Force Actuator near neighbors
+#define FA_MAX_NEAR_COUNT 7
+
+/// Number of Force Actuator neighbors
+#define FA_FAR_COUNT 12
 
 /// Number of hardpoints.
 #define HP_COUNT 6

--- a/include/cRIO/DataTypes.h
+++ b/include/cRIO/DataTypes.h
@@ -26,7 +26,6 @@
 
 #include <stdint.h>
 
-
 /**
  * Number of ModBus subnets. Subnets are connected and commanded through cRIO
  * DIOs.

--- a/include/cRIO/DataTypes.h
+++ b/include/cRIO/DataTypes.h
@@ -26,9 +26,6 @@
 
 #include <stdint.h>
 
-#define ACK_INPROGRESS 301  //* Acknowledges command reception, command is being executed.
-#define ACK_COMPLETE 303    //* Command is completed.
-#define ACK_FAILED -302     //* Command execution failed.
 
 /**
  * Number of ModBus subnets. Subnets are connected and commanded through cRIO

--- a/include/cRIO/FPGA.h
+++ b/include/cRIO/FPGA.h
@@ -122,8 +122,10 @@ public:
      * the data.
      *
      * @param mpu Modbus Processing Unit to read the data
+     *
+     * @return data read from the port
      */
-    virtual void readMPUFIFO(MPU& mpu) = 0;
+    virtual std::vector<uint8_t> readMPUFIFO(MPU& mpu) = 0;
 
     /**
      * Writes buffer to command FIFO. Command FIFO is processed in

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -46,6 +46,8 @@ namespace MPUCommands {
 const static uint8_t WRITE = 1;
 const static uint8_t READ_US = 2;
 const static uint8_t READ_MS = 3;
+const static uint8_t WAIT_US = 100;
+const static uint8_t WAIT_MS = 101;
 const static uint8_t IRQ = 240;
 const static uint8_t TELEMETRY = 254;
 const static uint8_t RESET = 255;
@@ -80,6 +82,20 @@ public:
      * Reset bus. Clear all FIFOs.
      */
     void resetBus();
+
+    /**
+     * Wait for given number of microseonds.
+     *
+     * @param us number of microseconds to wait
+     */ 
+    void waitUs(uint16_t us);
+
+    /**
+     * Wait for given number of milliseconds.
+     *
+     * @param ms number of milliseconds to wait
+     */
+    void waitMs(uint16_t ms);
 
     /**
      * Returns bus number (internal FPGA identifier).

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -87,7 +87,11 @@ public:
      * Wait for given number of microseonds.
      *
      * @param us number of microseconds to wait
+<<<<<<< HEAD
      */ 
+=======
+     */
+>>>>>>> cf704ee... Fixed IRQ responses
     void waitUs(uint16_t us);
 
     /**

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -87,11 +87,7 @@ public:
      * Wait for given number of microseonds.
      *
      * @param us number of microseconds to wait
-<<<<<<< HEAD
-     */ 
-=======
      */
->>>>>>> cf704ee... Fixed IRQ responses
     void waitUs(uint16_t us);
 
     /**

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -179,7 +179,7 @@ public:
      *
      * @param FPGA fpga used to process MPU commands.
      */
-    void runLoop(FPGA &fpga);
+    bool runLoop(FPGA &fpga);
 
     loop_state_t getLoopState() { return _loop_state; }
 

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -48,7 +48,7 @@ const static uint8_t READ_US = 2;
 const static uint8_t READ_MS = 3;
 const static uint8_t IRQ = 240;
 const static uint8_t TELEMETRY = 254;
-const static uint8_t CLEAR = 255;
+const static uint8_t RESET = 255;
 }  // namespace MPUCommands
 
 typedef enum { WRITE, READ, IDLE } loop_state_t;
@@ -75,6 +75,11 @@ public:
     MPU(uint8_t bus, uint8_t mpu_address);
 
     void clearCommanded();
+
+    /**
+     * Reset bus. Clear all FIFOs.
+     */
+    void resetBus();
 
     /**
      * Returns bus number (internal FPGA identifier).
@@ -145,6 +150,15 @@ public:
      * Called to write commands to retrieve values needed in loopRead.
      */
     virtual void loopWrite() = 0;
+
+    /**
+     * Exception raised when read timeouts.
+     */
+    class IRQTimeout : public std::runtime_error {
+    public:
+        IRQTimeout(std::vector<uint8_t> _data);
+        std::vector<uint8_t> data;
+    };
 
     /***
      * Called to process data read in the loop.

--- a/include/cRIO/ModbusBuffer.h
+++ b/include/cRIO/ModbusBuffer.h
@@ -505,6 +505,11 @@ public:
         EmptyCommanded(uint8_t address, uint8_t function);
     };
 
+    class MissingReply : public std::runtime_error {
+    public:
+        MissingReply(uint8_t address, uint8_t func);
+    };
+
     class UnmatchedFunction : public std::runtime_error {
     public:
         UnmatchedFunction(uint8_t address, uint8_t function);
@@ -520,6 +525,14 @@ protected:
     void pushBuffer(uint16_t data) { _buffer.push_back(data); }
     void incIndex() { _index++; }
     void resetCRC() { _crc.reset(); }
+
+    /**
+     * Called when a reply to command is missing.
+     *
+     * @parameter address ILC address
+     * @parameter func called function
+     */
+    virtual void handleMissingReply(uint8_t address, uint8_t func);
 
     /**
      * Return data item to write to buffer. Updates CRC counter.

--- a/include/cRIO/ModbusBuffer.h
+++ b/include/cRIO/ModbusBuffer.h
@@ -22,8 +22,10 @@
 #define CRIO_MODBUSBUFFER_H_
 
 #include <functional>
+#include <iomanip>
 #include <map>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <stdexcept>
 #include <vector>
@@ -177,6 +179,26 @@ public:
      * @return read data
      */
     std::vector<uint8_t> getReadData(int32_t length);
+
+    /**
+     * Dumps hex data to ostring stream.
+     *
+     *
+     * @param
+     */
+    template <typename dt>
+    static const std::string hexDump(dt* buf, size_t len) {
+        std::ostringstream os;
+        os << std::setfill('0') << std::hex;
+        for (size_t i = 0; i < len; i++) {
+            if (i > 0) {
+                os << " ";
+            }
+            os << std::setw(sizeof(dt) * 2) << +(buf[i]);
+        }
+        os << std::dec;
+        return os.str();
+    }
 
     /**
      * Reads data from buffer. Updates CRC as it reads the data. Size of

--- a/include/cRIO/NiError.h
+++ b/include/cRIO/NiError.h
@@ -46,37 +46,40 @@ public:
 };
 
 /**
- * Throws NI exception if an error occurred.
+ * Throws NI exception if an error occurred. Ignores positive status values, as
+ * those signal a warning  - see NiFpga_IsError.
  *
  * @param msg message associated with the error
  * @param status NI status
  *
- * @throw NiError if status != 0
+ * @throw NiError if status < 0
  *
  * @see NiError
  */
 void NiThrowError(const char *msg, int32_t status);
 
 /**
- * Throws NI exception if an error occurred.
+ * Throws NI exception if an error occurred. Ignores positive status values, as
+ * those signal a warning  - see NiFpga_IsError.
  *
  * @param msg message associated with the error
  * @param status NI status
  *
- * @throw NiError if status != 0
+ * @throw NiError if status < 0
  *
  * @see NiError
  */
 inline void NiThrowError(const std::string &msg, int32_t status) { NiThrowError(msg.c_str(), status); }
 
 /**
- * Throws NI exception if an error occurred.
+ * Throws NI exception if an error occurred. Ignores positive status values, as
+ * those signal a warning  - see NiFpga_IsError.
  *
  * @param func reporting function
  * @param ni_func Ni function name signaling the exception
  * @param status NI status
  *
- * @throw NiError if status != 0
+ * @throw NiError if status < 0
  *
  * @see NiError
  */

--- a/include/cRIO/PrintILC.h
+++ b/include/cRIO/PrintILC.h
@@ -177,4 +177,4 @@ private:
 }  // namespace cRIO
 }  // namespace LSST
 
-#endif  // !_cRIO_ILC_
+#endif  // !_cRIO_PrintILC_

--- a/include/cRIO/SAL/Command.h
+++ b/include/cRIO/SAL/Command.h
@@ -23,9 +23,11 @@
 namespace LSST {
 namespace cRIO {
 namespace SAL {
-constexpr int ACK_INPROGRESS = 301;
-constexpr int ACK_COMPLETE = 303;
-constexpr int ACK_FAILED = -302;
+
+constexpr int32_t ACK_INPROGRESS = 301;  /// Acknowledges command reception, command is being executed.
+constexpr int32_t ACK_COMPLETE = 303;    /// Command is completed.
+constexpr int32_t ACK_FAILED = -302;     /// Command execution failed.
+
 }  // namespace SAL
 }  // namespace cRIO
 }  // namespace LSST

--- a/src/LSST/cRIO/CliApp.cpp
+++ b/src/LSST/cRIO/CliApp.cpp
@@ -37,6 +37,7 @@
 
 #include "cRIO/CliApp.h"
 #include "cRIO/ModbusBuffer.h"
+#include "cRIO/OStreamRestore.h"
 #include "cRIO/Timestamp.h"
 
 namespace LSST {

--- a/src/LSST/cRIO/MPU.cpp
+++ b/src/LSST/cRIO/MPU.cpp
@@ -267,7 +267,6 @@ std::vector<uint8_t> MPU::getCommandVector() {
 void MPU::runLoop(FPGA& fpga) {
     switch (_loop_state) {
         case loop_state_t::WRITE:
-            clearCommanded();
             _loop_next_read = std::chrono::steady_clock::now() + _loop_timeout;
             loopWrite();
             fpga.writeMPUFIFO(*this);
@@ -287,6 +286,7 @@ void MPU::runLoop(FPGA& fpga) {
                 fpga.writeMPUFIFO(*this);
                 throw IRQTimeout(data);
             } else {
+                fpga.ackIrqs(getIrq());
                 fpga.readMPUFIFO(*this);
             }
 

--- a/src/LSST/cRIO/ModbusBuffer.cpp
+++ b/src/LSST/cRIO/ModbusBuffer.cpp
@@ -18,11 +18,13 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <iomanip>
+#include <ostream>
 #include <string.h>
 #include <sstream>
 
-#include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/spdlog.h>
 
 #include <cRIO/ModbusBuffer.h>
 #include <cRIO/Timestamp.h>

--- a/src/LSST/cRIO/NiError.cpp
+++ b/src/LSST/cRIO/NiError.cpp
@@ -31,7 +31,7 @@ NiError::NiError(const char *msg, NiFpga_Status status) : std::runtime_error(NiS
 }
 
 void NiThrowError(const char *msg, int32_t status) {
-    if (status != 0) {
+    if (status < 0) {
         throw NiError(msg, status);
     }
 }

--- a/tests/TestFPGA.h
+++ b/tests/TestFPGA.h
@@ -31,7 +31,7 @@ enum FPGAAddress { MODBUS_A_RX = 21, MODBUS_A_TX = 25, HEARTBEAT = 62 };  // nam
 
 class TestILC : public LSST::cRIO::PrintILC {
 public:
-    TestILC(uint8_t bus) : PrintILC(bus) {}
+    TestILC(uint8_t bus) : LSST::cRIO::PrintILC(bus) {}
 
 protected:
     void processChangeILCMode(uint8_t address, uint16_t mode) override;
@@ -49,7 +49,9 @@ public:
     uint16_t getRxCommand(uint8_t bus) override { return FPGAAddress::MODBUS_A_RX; }
     uint32_t getIrq(uint8_t bus) override { return 1; }
     void writeMPUFIFO(LSST::cRIO::MPU&) override {}
-    void readMPUFIFO(LSST::cRIO::MPU&) override {}
+    std::vector<uint8_t> readMPUFIFO(LSST::cRIO::MPU&) override {
+        return std::vector<uint8_t>({0xff, 0x0fe});
+    }
     void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t timeout) override;

--- a/tests/test_CSC.cpp
+++ b/tests/test_CSC.cpp
@@ -46,7 +46,7 @@ public:
     uint16_t getRxCommand(uint8_t) override { return 0; }
     uint32_t getIrq(uint8_t) override { return 0; }
     void writeMPUFIFO(MPU&) override {}
-    void readMPUFIFO(MPU&) override {}
+    std::vector<uint8_t> readMPUFIFO(MPU&) override { return std::vector<uint8_t>({0x04, 0x05}); }
     void writeCommandFIFO(uint16_t*, size_t, uint32_t) override {}
     void writeRequestFIFO(uint16_t*, size_t, uint32_t) override {}
     void readU16ResponseFIFO(uint16_t*, size_t, uint32_t) override {}

--- a/tests/test_FPGACliApp.cpp
+++ b/tests/test_FPGACliApp.cpp
@@ -27,7 +27,7 @@
 #include <cRIO/PrintILC.h>
 #include <cRIO/FPGACliApp.h>
 
-#include "TestFPGA.h"
+#include <TestFPGA.h>
 
 using namespace LSST::cRIO;
 

--- a/tests/test_FirmwareLoad.cpp
+++ b/tests/test_FirmwareLoad.cpp
@@ -56,7 +56,7 @@ public:
     uint32_t getIrq(uint8_t bus) override { return 1; }
 
     void writeMPUFIFO(MPU& mpu) override {}
-    void readMPUFIFO(MPU& mpu) override {}
+    std::vector<uint8_t> readMPUFIFO(MPU& mpu) override { return std::vector<uint8_t>({0x01, 0x02}); }
 
     void writeCommandFIFO(uint16_t* data, size_t length, uint32_t timeout) override;
     void writeRequestFIFO(uint16_t* data, size_t length, uint32_t timeout) override {}
@@ -134,7 +134,7 @@ void TestFPGA::readU16ResponseFIFO(uint16_t* data, size_t length, uint32_t timeo
 
 void TestFPGA::_printBuffer(uint16_t* data, size_t length, const char* prefix, bool cmp) {
     std::stringstream ss;
-    ss << prefix;
+    ss << prefix << " ";
     CliApp::printHexBuffer(data, length, ss);
     if (cmp) {
         std::string l;

--- a/tests/test_ILC.cpp
+++ b/tests/test_ILC.cpp
@@ -455,8 +455,7 @@ TEST_CASE("Unmatched response", "[ILC]") {
     ilc1.clear();
     ilc1.reportServerID(132);
     ilc1.reportServerStatus(141);
-    REQUIRE_THROWS_AS(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()),
-                      ModbusBuffer::UnmatchedFunction);
+    REQUIRE_THROWS_AS(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()), ModbusBuffer::MissingReply);
 
     // missing reply
     constructCommands();
@@ -476,8 +475,7 @@ TEST_CASE("Unmatched response", "[ILC]") {
 
     // invalid function
     ilc2.getBuffer()[1] = 0x1200 | (1 << 1);
-    REQUIRE_THROWS_AS(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()),
-                      ModbusBuffer::UnmatchedFunction);
+    REQUIRE_THROWS_AS(ilc1.processResponse(ilc2.getBuffer(), ilc2.getLength()), ModbusBuffer::MissingReply);
 
     // reset function
     ilc3.write<uint8_t>(17);

--- a/tests/test_ModbusBuffer.cpp
+++ b/tests/test_ModbusBuffer.cpp
@@ -366,3 +366,9 @@ TEST_CASE("CRC class constructed from buffer", "[ModbusBuffer::CRC]") {
 
     REQUIRE(crc.get() == 0x6310);
 }
+
+TEST_CASE("Hex dumping", "[ModbusBuffer::hexDump]") {
+    std::vector<uint8_t> data({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 255});
+
+    REQUIRE(ModbusBuffer::hexDump(data.data(), data.size()) == "01 02 03 04 05 06 07 08 09 0a 0b ff");
+}

--- a/tests/test_PrintILC.cpp
+++ b/tests/test_PrintILC.cpp
@@ -20,6 +20,8 @@
  * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+#define CATCH_CONFIG_MAIN
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <cRIO/IntelHex.h>

--- a/tests/test_PrintILC.cpp
+++ b/tests/test_PrintILC.cpp
@@ -27,7 +27,7 @@
 #include <cRIO/IntelHex.h>
 #include <cRIO/ILC.h>
 
-#include "TestFPGA.h"
+#include <TestFPGA.h>
 
 using namespace LSST::cRIO;
 


### PR DESCRIPTION
- handleMissingReply method
- IRQTimeout handling
- removed doc from clean directories
- Ignore warning status (positive for NI).
- Don't clear buffer before writing loop - enables command chaining
- runLoop returns bool - true if that's last call in a loop
- Fixed IRQ responses
- Expanded DataTypes.h
- Fixed IRQ responses
- Expanded DataTypes.h
- Moved ACK_<command status> to SAL/Command
- Fixed tests
