### PR TITLE
Functions to translate status bits into strings

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -5,6 +5,7 @@ Version History
 v1.10.0
 =======
 
+* getStringStatus function
 * handleMissingReply, MissingReply exception
 * IRQTimeout handling
 

--- a/include/cRIO/ILC.h
+++ b/include/cRIO/ILC.h
@@ -162,7 +162,49 @@ protected:
 
     uint8_t getLastMode(uint8_t address) { return _lastMode.at(address); }
 
+    /**
+     * Return string with current mode description.
+     *
+     * @param mode ILC mode, as returned by function 18.
+     *
+     * @return status description (enabled, standby,..).
+     */
     const char *getModeStr(uint8_t mode);
+
+    /**
+     * Return string with short text describing all code 18 status response.
+     *
+     * @param status status returned from function 18 (and other functions).
+     *
+     * @return vector of strings with status description
+     */
+    virtual std::vector<const char *> getStatusString(uint16_t status);
+
+    enum ILCStatus { MajorFault = 0x0001, MinorFault = 0x0002, FaultOverride = 0x0008 };
+
+    /**
+     * Return ILC fault textual description.
+     *
+     * @param fault ILC faults returned by function 18.
+     *
+     * @return vector of strings with fault description
+     */
+    virtual std::vector<const char *> getFaultString(uint16_t fault);
+
+    enum ILCFault {
+        UniqueIRC = 0x0001,
+        AppType = 0x0002,
+        NoILC = 0x0004,
+        ILCAppCRC = 0x0008,
+        NoTEDS = 0x0010,
+        TEDS1 = 0x0020,
+        TEDS2 = 0x0040,
+        WatchdogReset = 0x0100,
+        BrownOut = 0x0200,
+        EventTrap = 0x0400,
+        SSR = 0x1000,
+        AUX = 0x2000
+    };
 
     /**
      * Callback for reponse to ServerID request. See LTS-646 Code 17 (0x11) for

--- a/include/cRIO/ThermalILC.h
+++ b/include/cRIO/ThermalILC.h
@@ -47,6 +47,31 @@ public:
      */
     ThermalILC(uint8_t bus = 1);
 
+    std::vector<const char*> getStatusString(uint16_t status) override;
+
+    enum ThermalILCStatus {
+        RefResistor = 0x0040,
+        RTDError = 0x0080,
+        HeaterBreaker = 0x0400,
+        FanBreaker = 0x0800
+    };
+
+    /**
+     * Return thermal status. This is the lower nibble returned from thermal demand and status functions.
+     *
+     * @param status ILC status, including broadcast counter (can be ignored)
+     *
+     * @return description of bits set in status
+     */
+    std::vector<const char*> getThermalStatusString(uint8_t status);
+
+    enum ThermalStatus {
+        ILCFault = 0x0001,
+        HeaterDisabled = 0x0002,
+        HeaterBreakerOpen = 0x0004,
+        FanBreakerOpen = 0x0008
+    };
+
     /**
      * Unicast heater PWM and fan RPM. ILC command code 88 (0x58)
      *

--- a/src/LSST/cRIO/PrintILC.cpp
+++ b/src/LSST/cRIO/PrintILC.cpp
@@ -23,6 +23,8 @@
 #include <iomanip>
 #include <iostream>
 
+#include <spdlog/fmt/fmt.h>
+
 #include <cRIO/ModbusBuffer.h>
 #include <cRIO/PrintILC.h>
 #include <cRIO/SimulatedILC.h>
@@ -190,8 +192,10 @@ void PrintILC::processServerID(uint8_t address, uint64_t uniqueID, uint8_t ilcAp
 void PrintILC::processServerStatus(uint8_t address, uint8_t mode, uint16_t status, uint16_t faults) {
     printBusAddress(address);
     std::cout << "Mode: " << std::to_string(mode) << " - " << getModeStr(mode) << std::endl
-              << "Status: " << std::hex << std::setw(4) << std::setfill('0') << (status) << std::endl
-              << "Faults: " << std::hex << std::setw(4) << std::setfill('0') << (status) << std::endl;
+              << "Status: " << std::hex << std::setw(4) << std::setfill('0') << +status
+              << fmt::format("{}", fmt::join(getStatusString(status), " | ")) << std::endl
+              << "Faults: " << std::hex << std::setw(4) << std::setfill('0') << +faults
+              << fmt::format("{}", fmt::join(getFaultString(faults), " | ")) << std::endl;
 }
 
 void PrintILC::processChangeILCMode(uint8_t address, uint16_t mode) {


### PR DESCRIPTION
- ILC's getStatusString & getFaultString methods
- ILC's getStatusString & getFaultString methods
