### PR TITLE
DM-43211: Make things public so m2cli can use them

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -7,6 +7,7 @@ v1.11.0
 * Modbus::, ILC::ILCBusList classes. Communication code moved from ModbusBuffer
   to FPGA class.
 * Improved documentation.
+* Public constants to explain meaning of the numbers
 
 v1.10.1
 -------

--- a/include/ILC/ILCBusList.h
+++ b/include/ILC/ILCBusList.h
@@ -29,7 +29,7 @@
 
 namespace ILC {
 
-enum Mode { Standby = 0, Disabled = 1, Enabled = 2, FirmwareUpdate = 3, Fault = 4, ClearFaults = 5 };
+enum Mode { Standby = 0, Disabled = 1, Enabled = 2, Bootloader = 3, Fault = 4, ClearFaults = 5 };
 
 /**
  * Handles basic @glos{ILC} communication. Provides methods to run @glos{ILC}
@@ -113,6 +113,17 @@ public:
      * @param address @glos{ICL} address
      */
     void resetServer(uint8_t address) { callFunction(address, ILC_CMD::RESET_SERVER, 86840); }
+
+    /**
+     * ILC commands numbers. See LTS-346 and LTS-646 for details.
+     */
+    enum ILC_CMD {
+        SERVER_ID = 17,
+        SERVER_STATUS = 18,
+        CHANGE_MODE = 65,
+        SET_TEMP_ADDRESS = 72,
+        RESET_SERVER = 107
+    };
 
 protected:
     /**
@@ -315,17 +326,6 @@ private:
 
     std::map<uint8_t, uint8_t> _lastMode;  ///< last know @glos{ILC} mode
     uint8_t _broadcastCounter = 0;
-
-    /**
-     * ILC commands numbers. See LTS-346 and LTS-646 for details.
-     */
-    enum ILC_CMD {
-        SERVER_ID = 17,
-        SERVER_STATUS = 18,
-        CHANGE_MODE = 65,
-        SET_TEMP_ADDRESS = 72,
-        RESET_SERVER = 107
-    };
 };
 
 }  // namespace ILC

--- a/include/cRIO/ElectromechanicalPneumaticILC.h
+++ b/include/cRIO/ElectromechanicalPneumaticILC.h
@@ -56,6 +56,22 @@ public:
     ElectromechanicalPneumaticILC(uint8_t bus);
 
     /**
+     * Electromechanical ILC commands. See LTS-346 and LTS-646 for details.
+     */
+    enum ILC_EM_CMD {
+        SET_STEPPER_STEPS = 66,
+        STEPPER_FORCE_STATUS = 67,
+        SET_DCA_GAIN = 73,
+        REPORT_DCA_GAIN = 74,
+        SET_FORCE_OFFSET = 75,
+        REPORT_FA_FORCE_STATUS = 76,
+        SET_OFFSET_AND_SENSITIVITY = 81,
+        REPORT_CALIBRATION_DATA = 110,
+        REPORT_MEZZANINE_PRESSURE = 119,
+        REPORT_HARDPOINT_LVDT = 122
+    };
+
+    /**
      * Unicast command to command stepper motor moves.
      *
      * @param address @glos{ILC} address
@@ -304,23 +320,6 @@ protected:
      */
     virtual void processMezzaninePressure(uint8_t address, float primaryPush, float primaryPull,
                                           float secondaryPush, float secondaryPull) = 0;
-
-private:
-    /**
-     * Electromechanical ILC commands. See LTS-346 and LTS-646 for details.
-     */
-    enum ILC_EM_CMD {
-        SET_STEPPER_STEPS = 66,
-        STEPPER_FORCE_STATUS = 67,
-        SET_DCA_GAIN = 73,
-        REPORT_DCA_GAIN = 74,
-        SET_FORCE_OFFSET = 75,
-        REPORT_FA_FORCE_STATUS = 76,
-        SET_OFFSET_AND_SENSITIVITY = 81,
-        REPORT_CALIBRATION_DATA = 110,
-        REPORT_MEZZANINE_PRESSURE = 119,
-        REPORT_HARDPOINT_LVDT = 122
-    };
 };
 
 }  // namespace cRIO

--- a/include/cRIO/ElectromechanicalPneumaticILC.h
+++ b/include/cRIO/ElectromechanicalPneumaticILC.h
@@ -225,6 +225,12 @@ public:
         callFunction(address, ILC_EM_CMD::REPORT_HARDPOINT_LVDT, 400);
     }
 
+    /**
+     * Number of values stored in calibration registers. The index is used for
+     * different acctuators/load cells connected to the ILC.
+     */
+    static constexpr int CALIBRATION_LENGTH = 4;
+
 protected:
     /**
      * Called when response from call to command unicast 66 (0x42) and 67
@@ -292,20 +298,23 @@ protected:
      * Called when response from call to command 110 (0x6E) is read.
      *
      * @param address status returned from this ILC
-     * @param mainADCK[4] main ADC calibration Kn
-     * @param mainOffset[4] main sensor n offset
-     * @param mainSensitivity[4] main sensor n sensitivity
-     * @param backupADCK[4] backup ADC calibration Kn
-     * @param backupOffset[4] backup sensor n offset
-     * @param backupSensitivity[4] backup sensor n sensitivity
+     * @param mainADCK[CALIBRATION_LENGTH] main ADC calibration Kn
+     * @param mainOffset[CALIBRATION_LENGTH] main sensor n offset
+     * @param mainSensitivity[CALIBRATION_LENGTH] main sensor n sensitivity
+     * @param backupADCK[CALIBRATION_LENGTH] backup ADC calibration Kn
+     * @param backupOffset[CALIBRATION_LENGTH] backup sensor n offset
+     * @param backupSensitivity[CALIBRATION_LENGTH] backup sensor n sensitivity
      *
      * @ingroup M1M3_fa
      * @ingroup M1M3_hp
      * @ingroup M2
      */
-    virtual void processCalibrationData(uint8_t address, float mainADCK[4], float mainOffset[4],
-                                        float mainSensitivity[4], float backupADCK[4], float backupOffset[4],
-                                        float backupSensitivity[4]) = 0;
+    virtual void processCalibrationData(uint8_t address, float mainADCK[CALIBRATION_LENGTH],
+                                        float mainOffset[CALIBRATION_LENGTH],
+                                        float mainSensitivity[CALIBRATION_LENGTH],
+                                        float backupADCK[CALIBRATION_LENGTH],
+                                        float backupOffset[CALIBRATION_LENGTH],
+                                        float backupSensitivity[CALIBRATION_LENGTH]) = 0;
 
     /**
      * Called when response from call to command 119 is read.

--- a/include/cRIO/PrintILC.h
+++ b/include/cRIO/PrintILC.h
@@ -113,6 +113,16 @@ public:
      */
     void programILC(FPGA *fpga, uint8_t address, IntelHex &hex);
 
+    /**
+     * Please consult LTS-646 for details about the ILC commands.
+     */
+    enum ILC_CLI_CMD {
+        WRITE_APPLICATION_STATS = 100,
+        ERASE_APPLICATION = 101,
+        WRITE_APPLICATION_PAGE = 102,
+        WRITE_VERIFY_APPLICATION = 103
+    };
+
 protected:
     void processServerID(uint8_t address, uint64_t uniqueID, uint8_t ilcAppType, uint8_t networkNodeType,
                          uint8_t ilcSelectedOptions, uint8_t networkNodeOptions, uint8_t majorRev,
@@ -174,16 +184,6 @@ protected:
     virtual void printSepline();
 
 private:
-    /**
-     * Please consult LTS-646 for details about the ILC commands.
-     */
-    enum ILC_CLI_CMD {
-        WRITE_APPLICATION_STATS = 100,
-        ERASE_APPLICATION = 101,
-        WRITE_APPLICATION_PAGE = 102,
-        WRITE_VERIFY_APPLICATION = 103
-    };
-
     int _printout;
     uint8_t _lastAddress;
     ModbusBuffer::CRC _crc;

--- a/include/cRIO/ThermalILC.h
+++ b/include/cRIO/ThermalILC.h
@@ -73,6 +73,16 @@ public:
     };
 
     /**
+     * Thermal ILC command numbers. Please consult LTS-646 for details.
+     */
+    enum ILC_THERMAL_CMD {
+        SET_THERMAL_DEMAND = 88,
+        REPORT_THERMAL_STATUS = 89,
+        SET_REHEATER_GAINS = 92,
+        REPORT_REHEATER_GAINS = 93
+    };
+
+    /**
      * Unicast heater PWM and fan RPM. ILC command code 88 (0x58)
      *
      * @param address ILC address
@@ -143,17 +153,6 @@ protected:
      * @param integralGain Re-Heater integral gain
      */
     virtual void processReHeaterGains(uint8_t address, float proportionalGain, float integralGain) = 0;
-
-private:
-    /**
-     * Thermal ILC command numbers. Please consult LTS-646 for details.
-     */
-    enum ILC_THERMAL_CMD {
-        SET_THERMAL_DEMAND = 88,
-        REPORT_THERMAL_STATUS = 89,
-        SET_REHEATER_GAINS = 92,
-        REPORT_REHEATER_GAINS = 93
-    };
 };
 
 }  // namespace cRIO

--- a/src/ILC/ILCBusList.cpp
+++ b/src/ILC/ILCBusList.cpp
@@ -114,12 +114,12 @@ const char *ILCBusList::getModeStr(uint8_t mode) {
             return "Disabled";
         case Mode::Enabled:
             return "Enabled";
-        case Mode::FirmwareUpdate:
-            return "Firmware Updade";
+        case Mode::Bootloader:
+            return "Bootloader";
         case Mode::Fault:
             return "Fault";
         default:
-            return "unknow";
+            return "unknown";
     }
 }
 
@@ -189,8 +189,8 @@ std::vector<const char *> ILCBusList::getFaultString(uint16_t fault) {
 void ILCBusList::changeILCMode(uint8_t address, uint16_t mode) {
     uint32_t timeout = 335;
     try {
-        if ((getLastMode(address) == Mode::Standby && mode == Mode::FirmwareUpdate) ||
-            (getLastMode(address) == Mode::FirmwareUpdate && mode == Mode::Standby)) {
+        if ((getLastMode(address) == Mode::Standby && mode == Mode::Bootloader) ||
+            (getLastMode(address) == Mode::Bootloader && mode == Mode::Standby)) {
             timeout = 100000;
         }
     } catch (std::out_of_range &err) {

--- a/src/LSST/cRIO/FPGACliApp.cpp
+++ b/src/LSST/cRIO/FPGACliApp.cpp
@@ -73,7 +73,7 @@ FPGACliApp::FPGACliApp(const char* name, const char* description)
             "Change ILC mode to enabled");
     addILCCommand(
             "bootloader", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::Bootloader); },
-            "Change ILC mode to booloader"); 
+            "Change ILC mode to booloader");
     addILCCommand(
             "clear-faults", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::ClearFaults); },
             "Clear ILC faults");

--- a/src/LSST/cRIO/FPGACliApp.cpp
+++ b/src/LSST/cRIO/FPGACliApp.cpp
@@ -64,13 +64,16 @@ FPGACliApp::FPGACliApp(const char* name, const char* description)
             "status", [](ILCUnit u) { u.first->reportServerStatus(u.second); }, "Print ILC status");
     addILCCommand(
             "standby", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::Standby); },
-            "Change to standby mode");
+            "Change ILC mode to standby");
     addILCCommand(
             "disable", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::Disabled); },
-            "Change to disabled mode");
+            "Change ILC mode to disabled");
     addILCCommand(
             "enable", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::Enabled); },
-            "Change to enabled mode");
+            "Change ILC mode to enabled");
+    addILCCommand(
+            "bootloader", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::Bootloader); },
+            "Change ILC mode to booloader"); 
     addILCCommand(
             "clear-faults", [](ILCUnit u) { u.first->changeILCMode(u.second, ILC::Mode::ClearFaults); },
             "Clear ILC faults");

--- a/src/LSST/cRIO/PrintILC.cpp
+++ b/src/LSST/cRIO/PrintILC.cpp
@@ -99,8 +99,8 @@ void PrintILC::programILC(FPGA *fpga, uint8_t address, IntelHex &hex) {
     fpga->ilcCommands(*this, ILC_TIMEOUT);
     clear();
 
-    if (getLastMode(address) != ILC::Mode::FirmwareUpdate) {
-        changeILCMode(address, ILC::Mode::FirmwareUpdate);
+    if (getLastMode(address) != ILC::Mode::Bootloader) {
+        changeILCMode(address, ILC::Mode::Bootloader);
         fpga->ilcCommands(*this, ILC_TIMEOUT);
         clear();
     }
@@ -111,8 +111,8 @@ void PrintILC::programILC(FPGA *fpga, uint8_t address, IntelHex &hex) {
         clear();
     }
 
-    if (getLastMode(address) != ILC::Mode::FirmwareUpdate) {
-        throw std::runtime_error("Cannot transition to FirmwareUpdate mode");
+    if (getLastMode(address) != ILC::Mode::Bootloader) {
+        throw std::runtime_error("Cannot transition to Bootloader mode");
     }
 
     eraseILCApplication(address);


### PR DESCRIPTION
- Public command numbers, support for saving calibration values
- CALIBRATION_LENGTH
