### PR TITLE
DM-51135: LimitPID class, proper warnings

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -2,6 +2,10 @@
 Version History
 ###############
 
+v1.14.0
+-------
+* PIDParameters load method with default PIDParameters
+
 v1.13.1
 -------
 * TaskQueue remove method

--- a/include/ILC/ILCBusList.h
+++ b/include/ILC/ILCBusList.h
@@ -31,6 +31,23 @@ namespace ILC {
 
 enum Mode { Standby = 0, Disabled = 1, Enabled = 2, Bootloader = 3, Fault = 4, ClearFaults = 5 };
 
+enum Status { MajorFault = 0x0001, MinorFault = 0x0002, FaultOverride = 0x0008 };
+
+enum Fault {
+    UniqueIdCRC = 0x0001,
+    AppType = 0x0002,
+    NoApplication = 0x0004,
+    AppCRC = 0x0008,
+    NoTEDS = 0x0010,
+    TEDS1 = 0x0020,
+    TEDS2 = 0x0040,
+    WatchdogReset = 0x0100,
+    BrownOut = 0x0200,
+    EventTrap = 0x0400,
+    SSR = 0x1000,
+    AUX = 0x2000
+};
+
 /**
  * Handles basic @glos{ILC} communication. Provides methods to run @glos{ILC}
  * functions and callback for responses.
@@ -189,8 +206,6 @@ protected:
      */
     virtual std::vector<const char *> getStatusString(uint16_t status);
 
-    enum ILCStatus { MajorFault = 0x0001, MinorFault = 0x0002, FaultOverride = 0x0008 };
-
     /**
      * Returns last know mode (state) of the @glos{ILC} at the address.
      *
@@ -210,21 +225,6 @@ protected:
      * @return vector of strings with fault description
      */
     virtual std::vector<const char *> getFaultString(uint16_t fault);
-
-    enum ILCFault {
-        UniqueIRC = 0x0001,
-        AppType = 0x0002,
-        NoILC = 0x0004,
-        ILCAppCRC = 0x0008,
-        NoTEDS = 0x0010,
-        TEDS1 = 0x0020,
-        TEDS2 = 0x0040,
-        WatchdogReset = 0x0100,
-        BrownOut = 0x0200,
-        EventTrap = 0x0400,
-        SSR = 0x1000,
-        AUX = 0x2000
-    };
 
     /**
      * Callback for reponse to ServerID request. See LTS-646 Code 17 (0x11) for

--- a/include/PID/LimitedPID.h
+++ b/include/PID/LimitedPID.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of LSST cRIO package.
+ *
+ * Developed for the Vera C. Rubin Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIMIT_PID_H_
+#define LIMIT_PID_H_
+
+#include "PID/PID.h"
+
+namespace LSST {
+namespace PID {
+
+class LimitedPID : public PID {
+public:
+    LimitedPID(PIDParameters parameters, double action_min, double action_max);
+
+    virtual ~LimitedPID() {}
+
+    double process(double setpoint, double measurement) override;
+
+protected:
+    double _action_min;
+    double _action_max;
+};
+
+}  // namespace PID
+}  // namespace LSST
+
+#endif  // ! LIMITED_PID_H_

--- a/include/PID/PID.h
+++ b/include/PID/PID.h
@@ -53,6 +53,8 @@ public:
      */
     PID(PIDParameters parameters);
 
+    virtual ~PID() {}
+
     /**
      * Update PID parameters.
      */
@@ -63,7 +65,7 @@ public:
     /**
      * Run PID calculations, produce output.
      */
-    double process(double setpoint, double measurement);
+    virtual double process(double setpoint, double measurement);
 
     /**
      * Keep constant PID output. Used during slews.

--- a/include/PID/PIDParameters.h
+++ b/include/PID/PIDParameters.h
@@ -54,18 +54,34 @@ struct PIDParameters {
     }
 
     /**
-     * Load parameters from YAML node.
+     * Load PID parameters from YAML node.
      *
      * @param node YAML node with PID, N and Timestep keys
      *
      * @raise YAML::Exception on error
      */
-    void load(const YAML::Node &node) {
+    virtual void load(const YAML::Node &node) {
         timestep = node["Timestep"].as<double>(1);
         P = node["P"].as<double>();
         I = node["I"].as<double>();
         D = node["D"].as<double>();
         N = node["N"].as<double>();
+    }
+
+    /**
+     * Load PID parameters from YAML node, with default specified.
+     *
+     * @param node YAML node with PID, N and Timestep keys
+     * @param default_params default parameters - will be used for missing parameters
+     *
+     * @raise YAML::Exception on error
+     */
+    virtual void load(const YAML::Node &node, const PIDParameters &default_params) {
+        timestep = node["Timestep"].as<double>(default_params.timestep);
+        P = node["P"].as<double>(default_params.P);
+        I = node["I"].as<double>(default_params.I);
+        D = node["D"].as<double>(default_params.D);
+        N = node["N"].as<double>(default_params.N);
     }
 
     //* Length of step (seconds)

--- a/include/cRIO/ThermalILC.h
+++ b/include/cRIO/ThermalILC.h
@@ -33,6 +33,13 @@ namespace cRIO {
  */
 constexpr int NUM_TS_ILC = 96;
 
+enum ThermalILCStatus {
+    RefResistor = 0x0040,
+    RTDError = 0x0080,
+    HeaterBreaker = 0x0400,
+    FanBreaker = 0x0800
+};
+
 /**
  * Class for communication with Thermal ILCs.
  *
@@ -48,13 +55,6 @@ public:
     ThermalILC(uint8_t bus);
 
     std::vector<const char*> getStatusString(uint16_t status) override;
-
-    enum ThermalILCStatus {
-        RefResistor = 0x0040,
-        RTDError = 0x0080,
-        HeaterBreaker = 0x0400,
-        FanBreaker = 0x0800
-    };
 
     /**
      * Return thermal status. This is the lower nibble returned from thermal demand and status functions.

--- a/src/ILC/ILCBusList.cpp
+++ b/src/ILC/ILCBusList.cpp
@@ -112,14 +112,14 @@ const char *ILCBusList::getModeStr(uint8_t mode) {
 std::vector<const char *> ILCBusList::getStatusString(uint16_t status) {
     std::vector<const char *> ret;
 
-    if (status & ILCStatus::MajorFault) {
+    if (status & Status::MajorFault) {
         ret.push_back("Major Fault");
     }
-    if (status & ILCStatus::MinorFault) {
+    if (status & Status::MinorFault) {
         ret.push_back("Minor Fault");
     }
     // 0x0003 reserved
-    if (status & FaultOverride) {
+    if (status & Status::FaultOverride) {
         ret.push_back("Fault Override");
     }
     // remaining status is ILC specific, implemented in its *ILC subclass
@@ -130,42 +130,42 @@ std::vector<const char *> ILCBusList::getStatusString(uint16_t status) {
 std::vector<const char *> ILCBusList::getFaultString(uint16_t fault) {
     std::vector<const char *> ret;
 
-    if (fault & ILCFault::UniqueIRC) {
+    if (fault & Fault::UniqueIdCRC) {
         ret.push_back("Unique ID CRC error");
     }
-    if (fault & ILCFault::AppType) {
+    if (fault & Fault::AppType) {
         ret.push_back("App Type & Network Node Type do not match");
     }
-    if (fault & ILCFault::NoILC) {
+    if (fault & Fault::NoApplication) {
         ret.push_back("No ILC App programmed");
     }
-    if (fault & ILCFault::ILCAppCRC) {
+    if (fault & Fault::AppCRC) {
         ret.push_back("ILC App CRC error");
     }
-    if (fault & ILCFault::NoTEDS) {
+    if (fault & Fault::NoTEDS) {
         ret.push_back("No TEDS found");
     }
-    if (fault & ILCFault::TEDS1) {
+    if (fault & Fault::TEDS1) {
         ret.push_back("TEDS copy 1 error");
     }
-    if (fault & ILCFault::TEDS2) {
+    if (fault & Fault::TEDS2) {
         ret.push_back("TEDS copy 2 error");
     }
     // 0x0080 reserved
-    if (fault & ILCFault::WatchdogReset) {
+    if (fault & Fault::WatchdogReset) {
         ret.push_back("Reset due to Watchdog Timeout");
     }
-    if (fault & ILCFault::BrownOut) {
+    if (fault & Fault::BrownOut) {
         ret.push_back("Brown Out");
     }
-    if (fault & ILCFault::EventTrap) {
+    if (fault & Fault::EventTrap) {
         ret.push_back("Event Trap");
     }
     // 0x0800 Electromechanical only
-    if (fault & ILCFault::SSR) {
+    if (fault & Fault::SSR) {
         ret.push_back("SSR power fail");
     }
-    if (fault & ILCFault::AUX) {
+    if (fault & Fault::AUX) {
         ret.push_back("Aux power fail");
     }
 

--- a/src/LSST/PID/LimitedPID.cpp
+++ b/src/LSST/PID/LimitedPID.cpp
@@ -1,0 +1,37 @@
+/*
+ * This file is part of LSST cRIO package.
+ *
+ * Developed for the Vera C. Rubin Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "PID/LimitedPID.h"
+
+using namespace LSST::PID;
+
+LimitedPID::LimitedPID(PIDParameters parameters, double action_min, double action_max)
+        : PID(parameters), _action_min(action_min), _action_max(action_max) {}
+
+double LimitedPID::process(double setpoint, double measurement) {
+    PID::process(setpoint, measurement);
+
+    _control = std::min(std::max(_control, _action_min), _action_max);
+
+    return _control;
+}

--- a/tests/test_LimitedPID.cpp
+++ b/tests/test_LimitedPID.cpp
@@ -1,0 +1,62 @@
+/*
+ * This file is part of LSST M1M3 SS test suite. Tests software PID.
+ *
+ * Developed for the Vera C. Rubin Telescope and Site System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch_all.hpp>
+
+#include <cmath>
+
+#include "PID/LimitedPID.h"
+
+using namespace LSST::PID;
+
+TEST_CASE("Heater_PID", "[PID]") {
+    PIDParameters pparams(5.0, 0.6, 1.0, 0.2, 0.2);
+
+    LimitedPID pid(pparams, 0, 100);
+
+    double action;
+
+    for (int n = 0; n < 100; n++) {
+        action = pid.process(10.0, 2 * sin(M_PI * (n / 50.0)));
+        CHECK(action >= 0);
+        CHECK(action <= 100);
+    }
+
+    for (int n = 0; n < 10000; n++) {
+        action = pid.process(10.0, 10.5);
+        if (n > 50) {
+            CHECK(action == 0);
+        } else {
+            CHECK(action >= 0);
+            CHECK(action <= 100);
+        }
+    }
+
+    for (int n = 0; n < 100; n++) {
+        action = pid.process(10.0, 9.5);
+
+        if (n > 10) {
+            CHECK(action > 0);
+        }
+    }
+}


### PR DESCRIPTION
- **PIDParameters::load virtual, method with default parameters**
- **LimitedPID**
- **Moved error enums outside of classes.**
