### PR TITLE
BusList::missing_response method, Transport::MissingResponse error.

### DIFF
--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -4,7 +4,8 @@ Version History
 
 v1.14.0
 -------
-* PIDParameters load method with default PIDParameters
+* PIDParameters load method with default PIDParameters.
+* BusList::missing_response method.
 
 v1.13.1
 -------

--- a/include/Modbus/BusList.h
+++ b/include/Modbus/BusList.h
@@ -309,6 +309,11 @@ public:
     void add_response(uint8_t func, std::function<void(Parser)> action,
                       std::function<void(uint8_t, uint8_t)> error_action = nullptr);
 
+    /***
+     * Called when response wasn't received.
+     */
+    virtual void missing_response();
+
     void set_error_response(uint8_t func, std::function<void(uint8_t, uint8_t)> error_action);
 
     ErrorRecord get_error_record(uint8_t address) { return _errors[address]; }

--- a/include/Transports/Transport.h
+++ b/include/Transports/Transport.h
@@ -26,9 +26,27 @@
 #include <vector>
 
 #include <cRIO/Thread.h>
+#include <Modbus/Buffer.h>
 #include <Modbus/BusList.h>
 
 namespace Transports {
+
+/**
+ * Error thrown when a response is missing. This is mostly caused by an @glos{ILC} on
+ * the bus being dead/not reacting to the command send.
+ */
+class MissingResponse : public std::runtime_error {
+public:
+    /**
+     * Construct missing response exception.
+     *
+     * @param address Expected @glos{ILC} address, for which response wasn't received
+     * @param func Expected function which wasn't responded by the @glos{ILC}
+     */
+    MissingResponse(const Modbus::Buffer& commanded)
+            : std::runtime_error(
+                      fmt::format("Missing response to command '{0}'", Modbus::hexDump(commanded))) {}
+};
 
 /**
  * Base transport class. Provides abstract interface to write and read bytes to

--- a/include/cRIO/MPU.h
+++ b/include/cRIO/MPU.h
@@ -74,6 +74,8 @@ public:
 
     int responseLength(const std::vector<uint8_t> &response) override;
 
+    void missing_response() override;
+
     /**
      * Read input registers.
      */

--- a/src/LSST/cRIO/MPU.cpp
+++ b/src/LSST/cRIO/MPU.cpp
@@ -145,6 +145,11 @@ int MPU::responseLength(const std::vector<uint8_t> &response) {
     }
 }
 
+void MPU::missing_response() {
+    _commanded_info.pop_front();
+    BusList::missing_response();
+}
+
 void MPU::readInputStatus(uint16_t start_register_address, uint16_t count, uint32_t timing) {
     callFunction(_node_address, READ_INPUT_STATUS, timing, start_register_address, count);
     _commanded_info.emplace_back(start_register_address, count);

--- a/src/Modbus/BusList.cpp
+++ b/src/Modbus/BusList.cpp
@@ -100,6 +100,8 @@ void BusList::add_response(uint8_t func, std::function<void(Parser)> action,
     _functions.emplace(func, ResponseRecord(action, error_action));
 }
 
+void BusList::missing_response() { _parsed_index++; };
+
 void BusList::set_error_response(uint8_t func, std::function<void(uint8_t, uint8_t)> error_action) {
     _functions.at(func).error_action = error_action;
 }

--- a/src/Transports/Transport.cpp
+++ b/src/Transports/Transport.cpp
@@ -59,7 +59,8 @@ void Transport::execute_command(std::vector<uint8_t> command, Modbus::BusList& b
     }
 
     if (answer.empty()) {
-        throw std::runtime_error(fmt::format("Empty answer to {}", Modbus::hexDump(command)));
+        bus_list.missing_response();
+        throw MissingResponse(command);
     }
 
     bus_list.parse(answer);


### PR DESCRIPTION
Fixes reading replies when communication timeouts.